### PR TITLE
Bump the open-source-license group with 2 updates

### DIFF
--- a/src/Flow.UI/Flow.UI.csproj
+++ b/src/Flow.UI/Flow.UI.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.9" />
         <PackageReference Include="MudBlazor" Version="8.12.0" />
         <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>

--- a/src/Foundation.UI/Foundation.UI.csproj
+++ b/src/Foundation.UI/Foundation.UI.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.9" />
         <PackageReference Include="MudBlazor" Version="8.12.0" />
         <PackageReference Include="OneOf" Version="3.0.271" />
     </ItemGroup>


### PR DESCRIPTION
Bumps Microsoft.AspNetCore.Components from 9.0.8 to 9.0.9 Bumps Microsoft.AspNetCore.Components.Web from 9.0.8 to 9.0.9

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Components dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.AspNetCore.Components dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.AspNetCore.Components.Web dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.AspNetCore.Components.Web dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license ...