### PR TITLE
Bump the open-source-license group with 1 update

### DIFF
--- a/src/USA.Test/USA.Test.csproj
+++ b/src/USA.Test/USA.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="TUnit" Version="0.57.65" />
+    <PackageReference Include="TUnit" Version="0.58.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps TUnit from 0.57.65 to 0.58.3

---
updated-dependencies:
- dependency-name: TUnit dependency-version: 0.58.3 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: open-source-license ...