### PR TITLE
Bump the open-source-license group with 2 updates

### DIFF
--- a/src/MegaSchool1/MegaSchool1.csproj
+++ b/src/MegaSchool1/MegaSchool1.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.SourceGenerator" Version="3.0.271" />
-    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.1" />
+    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
     <PackageReference Include="Riok.Mapperly" Version="4.2.1" />
     <PackageReference Include="Serilog" Version="4.3.0" />

--- a/src/USA.Test/USA.Test.csproj
+++ b/src/USA.Test/USA.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="TUnit" Version="0.58.3" />
+    <PackageReference Include="TUnit" Version="0.61.13" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps PublishSPAforGitHubPages.Build from 3.0.1 to 3.0.3 Bumps TUnit from 0.58.3 to 0.61.13

---
updated-dependencies:
- dependency-name: PublishSPAforGitHubPages.Build dependency-version: 3.0.3 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: TUnit dependency-version: 0.61.13 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: open-source-license ...